### PR TITLE
fix python3 path bug

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -38,7 +38,9 @@ class VolatilityAnalyzer:
         if not output_dir:
             timestamp = time.strftime('%Y-%m-%d_%H:%M:%S')
             output_dir = Path('/tmp') / f'volatility_analysis_{timestamp}'
-
+        else:
+            output_dir = Path(output_dir)  # Ensure output_dir is a Path object
+        
         output_dir.mkdir(parents=True, exist_ok=True)  # Create directory recursively
         return output_dir
 


### PR DESCRIPTION
ERROR:root:Critical error: 'str' object has no attribute 'mkdir'

Description:
Fixed path handling bug: The issue where output_dir was being treated as a string instead of a Path object has been resolved. This fix ensures that Path.mkdir() works correctly by explicitly converting output_dir to a Path object before invoking the method.

Changes:
Added a conversion of output_dir to a Path object if it was provided as a string.
Ensured the directory creation logic (mkdir) works as expected when output_dir is either None or a string.

Motivation:
The bug occurred when the mkdir() method was called on a string, which doesn't have this method. This fix ensures proper handling of paths, allowing directory creation to work without errors.

How to test:
Verify that the _setup_output_dir() function correctly creates directories when passed a string or None.
Ensure that no AttributeError is raised when calling mkdir.
